### PR TITLE
Voice-based task manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# Task-Manager
-# Task-Manager
+# Task Manager
+
+This project is a simple voice-driven task manager. It uses FastAPI with SQLite to store tasks and an HTML/JavaScript front end to display them. Voice input is transcribed with OpenAI Whisper, and a custom LLM API can process commands from the transcription.
+
+## Requirements
+
+- Python 3.10+
+- `ffmpeg` for audio processing
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the development server:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Then open `http://localhost:8000` in your browser.

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+from . import models, schemas
+
+STATUSES = {"pending", "inprogress", "done"}
+
+def create_task(db: Session, task: schemas.TaskCreate) -> models.Task:
+    db_task = models.Task(description=task.description, status=task.status)
+    db.add(db_task)
+    db.commit()
+    db.refresh(db_task)
+    return db_task
+
+
+def list_tasks(db: Session):
+    return db.query(models.Task).all()
+
+
+def update_task(db: Session, task_id: int, task: schemas.TaskUpdate):
+    db_task = db.query(models.Task).filter(models.Task.id == task_id).first()
+    if not db_task:
+        return None
+    if task.description is not None:
+        db_task.description = task.description
+    if task.status is not None and task.status in STATUSES:
+        db_task.status = task.status
+    db.commit()
+    db.refresh(db_task)
+    return db_task

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,15 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = 'sqlite:///./tasks.db'
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI, UploadFile, File, Depends, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy.orm import Session
+from .db import Base, engine, get_db
+from . import models, schemas, crud
+import whisper
+import requests
+import os
+
+app = FastAPI()
+
+# create database tables
+Base.metadata.create_all(bind=engine)
+
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    with open("app/static/index.html") as f:
+        return HTMLResponse(f.read())
+
+@app.post("/tasks", response_model=schemas.TaskRead)
+async def create_task(task: schemas.TaskCreate, db: Session = Depends(get_db)):
+    return crud.create_task(db, task)
+
+@app.get("/tasks", response_model=list[schemas.TaskRead])
+async def get_tasks(db: Session = Depends(get_db)):
+    return crud.list_tasks(db)
+
+@app.put("/tasks/{task_id}", response_model=schemas.TaskRead)
+async def update_task(task_id: int, task: schemas.TaskUpdate, db: Session = Depends(get_db)):
+    db_task = crud.update_task(db, task_id, task)
+    if db_task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return db_task
+
+@app.post("/transcribe")
+async def transcribe_audio(file: UploadFile = File(...)):
+    model = whisper.load_model("base")
+    audio = await file.read()
+    with open("temp.wav", "wb") as f:
+        f.write(audio)
+    result = model.transcribe("temp.wav")
+    os.remove("temp.wav")
+    return {"text": result["text"]}
+
+@app.post("/llm")
+async def process_llm(text: str):
+    url = os.getenv("LLM_API_URL")
+    if not url:
+        raise HTTPException(status_code=500, detail="LLM_API_URL not set")
+    resp = requests.post(url, json={"text": text}, timeout=60)
+    resp.raise_for_status()
+    return resp.json()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer, String
+from .db import Base
+
+class Task(Base):
+    __tablename__ = 'tasks'
+
+    id = Column(Integer, primary_key=True, index=True)
+    description = Column(String, nullable=False)
+    status = Column(String, default='pending')

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+class TaskCreate(BaseModel):
+    description: str
+    status: str = 'pending'
+
+class TaskUpdate(BaseModel):
+    description: str | None = None
+    status: str | None = None
+
+class TaskRead(BaseModel):
+    id: int
+    description: str
+    status: str
+
+    class Config:
+        orm_mode = True

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Task Manager</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .column { float: left; width: 30%; padding: 10px; }
+        .column h2 { text-align: center; }
+        .task { border: 1px solid #ccc; padding: 5px; margin-bottom: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Voice Task Manager</h1>
+    <button id="record">Start Recording</button>
+    <pre id="transcript"></pre>
+    <div id="columns">
+        <div class="column" id="pending">
+            <h2>Pending</h2>
+        </div>
+        <div class="column" id="inprogress">
+            <h2>In Progress</h2>
+        </div>
+        <div class="column" id="done">
+            <h2>Done</h2>
+        </div>
+    </div>
+    <script>
+    async function fetchTasks(){
+        let resp = await fetch('/tasks');
+        let tasks = await resp.json();
+        ['pending','inprogress','done'].forEach(s => {
+            document.getElementById(s).innerHTML = '<h2>'+ (s === 'inprogress' ? 'In Progress' : s.charAt(0).toUpperCase()+s.slice(1)) +'</h2>';
+        });
+        tasks.forEach(t => {
+            let div = document.createElement('div');
+            div.className = 'task';
+            div.textContent = t.description;
+            document.getElementById(t.status).appendChild(div);
+        });
+    }
+    fetchTasks();
+
+    let mediaRecorder;
+    const button = document.getElementById('record');
+    button.addEventListener('click', async () => {
+        if (mediaRecorder && mediaRecorder.state === 'recording') {
+            mediaRecorder.stop();
+            button.textContent = 'Start Recording';
+        } else {
+            let stream = await navigator.mediaDevices.getUserMedia({audio:true});
+            mediaRecorder = new MediaRecorder(stream);
+            const chunks = [];
+            mediaRecorder.ondataavailable = e => chunks.push(e.data);
+            mediaRecorder.onstop = async () => {
+                let blob = new Blob(chunks, {type:'audio/wav'});
+                let form = new FormData();
+                form.append('file', blob, 'recording.wav');
+                let r = await fetch('/transcribe', {method:'POST', body: form});
+                let {text} = await r.json();
+                document.getElementById('transcript').textContent = text;
+                // call custom LLM API
+                let llm = await fetch('/llm', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({text})});
+                console.log(await llm.json());
+            };
+            mediaRecorder.start();
+            button.textContent = 'Stop Recording';
+        }
+    });
+    </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+python-multipart
+openai-whisper
+requests

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_create_and_get_tasks():
+    resp = client.post('/tasks', json={'description':'Test task'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['description'] == 'Test task'
+
+    resp = client.get('/tasks')
+    assert resp.status_code == 200
+    tasks = resp.json()
+    assert any(t['description'] == 'Test task' for t in tasks)


### PR DESCRIPTION
## Summary
- implement a FastAPI backend with SQLite using SQLAlchemy
- create REST endpoints for tasks and voice transcription
- add HTML/JS front-end to show pending, in progress, and done tasks
- use OpenAI Whisper for voice-to-text and expose LLM integration endpoint
- include a simple pytest test for task creation

## Testing
- `pip install -r requirements.txt` *(fails: Network is unreachable)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6847cfe12c0c8326a69e0d6e05f9263c