### PR TITLE
Lazy import for whisper model

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,6 @@ from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import Session
 from .db import Base, engine, get_db
 from . import models, schemas, crud
-import whisper
 import requests
 import os
 
@@ -37,6 +36,11 @@ async def update_task(task_id: int, task: schemas.TaskUpdate, db: Session = Depe
 
 @app.post("/transcribe")
 async def transcribe_audio(file: UploadFile = File(...)):
+    try:
+        import whisper
+    except ModuleNotFoundError:
+        raise HTTPException(status_code=500, detail="whisper package not installed")
+
     model = whisper.load_model("base")
     audio = await file.read()
     with open("temp.wav", "wb") as f:


### PR DESCRIPTION
## Summary
- defer whisper import in `transcribe_audio` so the server can start without the dependency
- handle missing whisper package gracefully

## Testing
- `PYTHONPATH=. pytest -q`
- `uvicorn app.main:app --reload --port 8001` (terminated after confirming startup)


------
https://chatgpt.com/codex/tasks/task_e_684806e418748326a0738407690bab7d