### PR TITLE
Add whisper model selection and LLM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Task Manager
 
-This project is a simple voice-driven task manager. It uses FastAPI with SQLite to store tasks and an HTML/JavaScript front end to display them. Voice input is transcribed with OpenAI Whisper, and a custom LLM API can process commands from the transcription.
+This project is a simple voice-driven task manager. It uses FastAPI with SQLite to store tasks and an HTML/JavaScript front end to display them. Voice input is transcribed with OpenAI Whisper, and a button in the UI lets you choose and download a model. Commands are interpreted using the OpenRouter **Gemini Flash** model which creates or updates tasks based on your speech.
 
 ## Requirements
 
@@ -20,3 +20,9 @@ uvicorn app.main:app --reload
 ```
 
 Then open `http://localhost:8000` in your browser.
+
+Set the following environment variable so the application can talk to OpenRouter:
+
+```
+export OPENROUTER_API_KEY=your_key_here
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,24 @@
-from fastapi import FastAPI, UploadFile, File, Depends, HTTPException
+from fastapi import FastAPI, UploadFile, File, Depends, HTTPException, Query
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import Session
 from .db import Base, engine, get_db
 from . import models, schemas, crud
-import whisper
+try:
+    import whisper  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    whisper = None
 import requests
+import json
 import os
 
 app = FastAPI()
+
+# Cache for loaded whisper models so they are downloaded only once
+if whisper is not None:
+    MODEL_CACHE: dict[str, whisper.Whisper] = {}
+else:  # pragma: no cover - whisper not installed
+    MODEL_CACHE: dict[str, object] = {}
 
 # create database tables
 Base.metadata.create_all(bind=engine)
@@ -20,6 +30,17 @@ async def index():
     with open("app/static/index.html") as f:
         return HTMLResponse(f.read())
 
+
+def get_model(name: str):
+    """Load a Whisper model by name and cache it."""
+    if whisper is None:
+        raise HTTPException(status_code=500, detail="whisper not installed")
+    model = MODEL_CACHE.get(name)
+    if model is None:
+        model = whisper.load_model(name)
+        MODEL_CACHE[name] = model
+    return model
+
 @app.post("/tasks", response_model=schemas.TaskRead)
 async def create_task(task: schemas.TaskCreate, db: Session = Depends(get_db)):
     return crud.create_task(db, task)
@@ -27,6 +48,13 @@ async def create_task(task: schemas.TaskCreate, db: Session = Depends(get_db)):
 @app.get("/tasks", response_model=list[schemas.TaskRead])
 async def get_tasks(db: Session = Depends(get_db)):
     return crud.list_tasks(db)
+
+
+@app.get("/download_model")
+async def download_model(model: str = Query("base")):
+    """Pre-download a Whisper model so it is ready for transcription."""
+    get_model(model)
+    return {"status": "downloaded"}
 
 @app.put("/tasks/{task_id}", response_model=schemas.TaskRead)
 async def update_task(task_id: int, task: schemas.TaskUpdate, db: Session = Depends(get_db)):
@@ -36,20 +64,69 @@ async def update_task(task_id: int, task: schemas.TaskUpdate, db: Session = Depe
     return db_task
 
 @app.post("/transcribe")
-async def transcribe_audio(file: UploadFile = File(...)):
-    model = whisper.load_model("base")
+async def transcribe_audio(
+    file: UploadFile = File(...), model: str = Query("base")
+):
+    model_instance = get_model(model)
     audio = await file.read()
     with open("temp.wav", "wb") as f:
         f.write(audio)
-    result = model.transcribe("temp.wav")
+    result = model_instance.transcribe("temp.wav")
     os.remove("temp.wav")
     return {"text": result["text"]}
 
 @app.post("/llm")
-async def process_llm(text: str):
-    url = os.getenv("LLM_API_URL")
-    if not url:
-        raise HTTPException(status_code=500, detail="LLM_API_URL not set")
-    resp = requests.post(url, json={"text": text}, timeout=60)
+async def process_llm(text: str, db: Session = Depends(get_db)):
+    """Use the OpenRouter Gemini Flash model to interpret the user's intent."""
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="OPENROUTER_API_KEY not set")
+
+    url = "https://openrouter.ai/api/v1/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": "google/gemini-flash-1.5",
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a task manager assistant. "
+                    "Extract the user's intent from the text and respond with a JSON "
+                    "object. Supported actions are 'create' and 'update'. For 'create', "
+                    "provide 'description' and optional 'status'. For 'update', provide "
+                    "'id' and 'status'. Respond only with JSON."
+                ),
+            },
+            {"role": "user", "content": text},
+        ],
+    }
+    resp = requests.post(url, headers=headers, json=payload, timeout=60)
     resp.raise_for_status()
-    return resp.json()
+
+    content = resp.json()["choices"][0]["message"]["content"]
+    try:
+        command = json.loads(content)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=500, detail="Invalid response from LLM")
+
+    action = command.get("action")
+    if action == "create":
+        description = command.get("description")
+        status = command.get("status", "pending")
+        if not description:
+            raise HTTPException(status_code=400, detail="Description required")
+        task = crud.create_task(db, schemas.TaskCreate(description=description, status=status))
+        return schemas.TaskRead.from_orm(task)
+    elif action == "update":
+        task_id = command.get("id")
+        status = command.get("status")
+        if task_id is None or status is None:
+            raise HTTPException(status_code=400, detail="id and status required")
+        task = crud.update_task(db, task_id, schemas.TaskUpdate(status=status))
+        if task is None:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return schemas.TaskRead.from_orm(task)
+    return {"message": "No action"}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -3,17 +3,30 @@
 <head>
     <meta charset="utf-8">
     <title>Task Manager</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <style>
-        body { font-family: Arial, sans-serif; }
-        .column { float: left; width: 30%; padding: 10px; }
-        .column h2 { text-align: center; }
-        .task { border: 1px solid #ccc; padding: 5px; margin-bottom: 5px; }
+        body { padding: 20px; }
+        .task { border: 1px solid #ccc; padding: 5px; margin-bottom: 5px; border-radius: 4px; }
+        #columns { display: flex; gap: 10px; }
+        .column { flex: 1; }
     </style>
 </head>
 <body>
-    <h1>Voice Task Manager</h1>
-    <button id="record">Start Recording</button>
-    <pre id="transcript"></pre>
+    <h1 class="mb-4">Voice Task Manager</h1>
+    <div class="mb-3 d-flex align-items-end gap-2">
+        <div>
+            <label for="modelSelect" class="form-label">Whisper model</label>
+            <select id="modelSelect" class="form-select">
+                <option value="base">base</option>
+                <option value="small">small</option>
+                <option value="medium">medium</option>
+                <option value="large">large</option>
+            </select>
+        </div>
+        <button id="downloadModel" class="btn btn-secondary mt-4">Download Model</button>
+        <button id="record" class="btn btn-primary mt-4">Start Recording</button>
+    </div>
+    <pre id="transcript" class="bg-light p-2"></pre>
     <div id="columns">
         <div class="column" id="pending">
             <h2>Pending</h2>
@@ -43,6 +56,12 @@
 
     let mediaRecorder;
     const button = document.getElementById('record');
+    const modelSelect = document.getElementById('modelSelect');
+    document.getElementById('downloadModel').addEventListener('click', async () => {
+        const m = modelSelect.value;
+        await fetch('/download_model?model=' + m);
+    });
+
     button.addEventListener('click', async () => {
         if (mediaRecorder && mediaRecorder.state === 'recording') {
             mediaRecorder.stop();
@@ -56,17 +75,19 @@
                 let blob = new Blob(chunks, {type:'audio/wav'});
                 let form = new FormData();
                 form.append('file', blob, 'recording.wav');
-                let r = await fetch('/transcribe', {method:'POST', body: form});
+                let model = modelSelect.value;
+                let r = await fetch('/transcribe?model=' + model, {method:'POST', body: form});
                 let {text} = await r.json();
                 document.getElementById('transcript').textContent = text;
-                // call custom LLM API
-                let llm = await fetch('/llm', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({text})});
-                console.log(await llm.json());
+                let llmResp = await fetch('/llm', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({text})});
+                console.log(await llmResp.json());
+                fetchTasks();
             };
             mediaRecorder.start();
             button.textContent = 'Stop Recording';
         }
     });
-    </script>
+</script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance landing page with Bootstrap styling and a dropdown to choose whisper model
- add ability to download whisper model and use it for transcription
- integrate OpenRouter Gemini Flash model to parse voice commands and update tasks
- document environment setup for OpenRouter
- make optional dependency on whisper for running tests

## Testing
- `pip install fastapi uvicorn sqlalchemy pydantic python-multipart requests`
- `pip install httpx`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493fcb5fe88326b0d30a31f66a7250